### PR TITLE
Skip builtin features

### DIFF
--- a/compile-angel.el
+++ b/compile-angel.el
@@ -723,14 +723,11 @@ Returns nil for features provided directly by C code."
     (let ((feature-symbol (if (symbolp feature-name) 
                              feature-name 
                            (intern feature-name))))
-      ;; First check if it's a built-in feature
-      (unless (gethash feature-symbol compile-angel--builtin-features-table nil)
-        ;; Only do the expensive lookup if not a built-in feature
-        (let* ((history-regexp (load-history-regexp feature-name))
-               (history-file (and (stringp history-regexp)
-                                 (load-history-filename-element history-regexp))))
-          (and (listp history-file)
-               (compile-angel--normalize-el-file (car history-file))))))))
+      (let* ((history-regexp (load-history-regexp feature-name))
+             (history-file (and (stringp history-regexp)
+                                (load-history-filename-element history-regexp))))
+        (and (listp history-file)
+             (compile-angel--normalize-el-file (car history-file)))))))
 
 (defun compile-angel--locate-feature-file (feature-or-file nosuffix)
   "Locate a file for FEATURE-OR-FILE using `locate-file'.

--- a/compile-angel.el
+++ b/compile-angel.el
@@ -720,8 +720,8 @@ This shows how effective the file index optimization has been."
 Uses `load-history' to determine the file where the feature was loaded from.
 Returns nil for features provided directly by C code."
   (when feature-name
-    (let ((feature-symbol (if (symbolp feature-name) 
-                             feature-name 
+    (let ((feature-symbol (if (symbolp feature-name)
+                             feature-name
                            (intern feature-name))))
       (let* ((history-regexp (load-history-regexp feature-name))
              (history-file (and (stringp history-regexp)
@@ -1037,15 +1037,6 @@ NEW-VALUE is the value of the variable."
                                           nil nil)
     (add-variable-watcher 'compile-angel-excluded-files
                           #'compile-angel--update-el-file-regexp)
-
-    ;; Ensure the built-in features table is initialized
-    (unless (hash-table-p compile-angel--builtin-features-table)
-      (setq compile-angel--builtin-features-table
-            (let ((table (make-hash-table :test 'eq 
-                                         :size (length compile-angel--builtin-features))))
-              (dolist (feature compile-angel--builtin-features)
-                (puthash feature t table))
-              table)))
 
     ;; Build the file index if enabled
     (when compile-angel-use-file-index

--- a/compile-angel.el
+++ b/compile-angel.el
@@ -92,7 +92,10 @@
   '(tty-child-frames xwidget-internal move-toolbar dbusbind native-compile
     font-render-setting system-font-setting dynamic-setting android inotify
     x xinput2 x-toolkit motif gtk cairo gfilenotify haiku multi-tty
-    make-network-process threads w32notify pgtk w32 lcms2 kqueue)
+    make-network-process threads w32notify pgtk w32 lcms2 kqueue emacs mps
+    hashtable-print-readable code-pages base64 md5 sha1 overlay text-properties
+    lisp-float-type dynamic-modules jansson harfbuzz byte-compile :system
+    noutline multi-isearch dotassoc)
   "Features that are provided directly by C code without associated Elisp files.")
 
 (defvar compile-angel--c-provided-features-table
@@ -790,13 +793,6 @@ resolved file path or nil if not found."
     ;; Fast path: if we have an absolute path that's an el file, just return it
     ;; El File
     (cond
-     ;; Skip C-provided features
-     ((and feature-symbol 
-           (gethash feature-symbol compile-angel--c-provided-features-table nil))
-      (compile-angel--debug-message
-       "compile-angel--guess-el-file: SKIP (C-provided feature): %s" feature-symbol)
-      nil)
-     
      ((and el-file
            (stringp el-file)
            (file-name-absolute-p el-file)
@@ -815,6 +811,13 @@ resolved file path or nil if not found."
         (compile-angel--debug-message
          "compile-angel--guess-el-file: CACHE: %s" file-index-result)
         file-index-result))
+
+     ;; Skip C-provided features
+     ((and feature-symbol
+           (gethash feature-symbol compile-angel--c-provided-features-table nil))
+      (compile-angel--debug-message
+       "compile-angel--guess-el-file: SKIP (C-provided feature): %s" feature-symbol)
+      nil)
 
      ;; Experimental feature
      ;; Try load-history if feature is loaded


### PR DESCRIPTION
Hey. I have made another big optimization. Basically, there are a bunch of features provided in the Emacs code, mostly by the C source that have no associated `.el` file. So I looked at the `compile-angel` debug log and hard-coded these as having no elisp file. This is the before and after time I am getting from this optimization:
```elisp
(list
 (let ((compile-angel-use-file-index t)
       (compile-angel-guess-el-file-use-load-history t))
   (clrhash compile-angel--list-compiled-files)
   (clrhash compile-angel--file-index)
   (clrhash compile-angel--no-byte-compile-files-list)
   (clrhash compile-angel--list-jit-native-compiled-files)
   (setq compile-angel--file-index-hits 0
         compile-angel--file-index-misses 0)
   (benchmark-run 1
     (compile-angel--build-file-index)
     (compile-angel-on-load-mode +1)))
 (let ((compile-angel-use-file-index nil)
       (compile-angel-guess-el-file-use-load-history nil))
   (clrhash compile-angel--list-compiled-files)
   (clrhash compile-angel--file-index)
   (clrhash compile-angel--no-byte-compile-files-list)
   (clrhash compile-angel--list-jit-native-compiled-files)
   (clrhash compile-angel--list-compiled-features)
   (benchmark-run 1
     (compile-angel-on-load-mode +1))))
;; before => ((0.45016236099999996 0 0.0) (2.520944078 0 0.0))
;; after => ((0.118096803 0 0.0) (2.130050591 0 0.0)) (EDITED FOR LATEST VERSION)
```
That's a 4x speedup for me when using the cache!